### PR TITLE
fix(wire): match TS createAction wire format (C3)

### DIFF
--- a/src/signer/methods/create_action.rs
+++ b/src/signer/methods/create_action.rs
@@ -18,8 +18,8 @@ use crate::signer::types::{
     PendingSignAction, SignableTransactionRef, SignerCreateActionResult, ValidCreateActionArgs,
 };
 use crate::storage::action_types::{
-    StorageCreateActionArgs, StorageCreateActionInput, StorageCreateActionOutput,
-    StorageProcessActionArgs,
+    StorageCreateActionArgs, StorageCreateActionInput, StorageCreateActionOptions,
+    StorageCreateActionOutput, StorageOutPoint, StorageProcessActionArgs,
 };
 use crate::storage::manager::WalletStorageManager;
 use crate::wallet::types::AuthId;
@@ -29,18 +29,56 @@ fn bytes_to_hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
+/// Parse an OutpointString ("txid.vout") into a StorageOutPoint.
+fn parse_outpoint_string(s: &str) -> StorageOutPoint {
+    let parts: Vec<&str> = s.rsplitn(2, '.').collect();
+    if parts.len() == 2 {
+        StorageOutPoint {
+            txid: parts[1].to_string(),
+            vout: parts[0].parse().unwrap_or(0),
+        }
+    } else {
+        StorageOutPoint {
+            txid: s.to_string(),
+            vout: 0,
+        }
+    }
+}
+
 /// Convert ValidCreateActionArgs to StorageCreateActionArgs.
 ///
 /// Strips unlocking scripts (storage only needs the length).
+/// Maps SDK CreateActionOptions to StorageCreateActionOptions.
 fn to_storage_args(args: &ValidCreateActionArgs) -> StorageCreateActionArgs {
+    use bsv::wallet::types::{BooleanDefaultFalse, BooleanDefaultTrue};
+
+    let opts = &args.options;
+    let storage_options = StorageCreateActionOptions {
+        sign_and_process: BooleanDefaultTrue(opts.sign_and_process.0),
+        accept_delayed_broadcast: BooleanDefaultTrue(opts.accept_delayed_broadcast.0),
+        trust_self: opts.trust_self.as_ref().map(|ts| ts.as_str().to_string()),
+        known_txids: opts.known_txids.clone(),
+        return_txid_only: BooleanDefaultFalse(opts.return_txid_only.0),
+        no_send: BooleanDefaultFalse(opts.no_send.0),
+        no_send_change: opts
+            .no_send_change
+            .iter()
+            .map(|s| parse_outpoint_string(s))
+            .collect(),
+        send_with: opts.send_with.clone(),
+        randomize_outputs: BooleanDefaultTrue(opts.randomize_outputs.0),
+    };
+
     StorageCreateActionArgs {
         description: args.description.clone(),
         inputs: args
             .inputs
             .iter()
             .map(|i| StorageCreateActionInput {
-                outpoint_txid: i.outpoint.txid.clone(),
-                outpoint_vout: i.outpoint.vout,
+                outpoint: StorageOutPoint {
+                    txid: i.outpoint.txid.clone(),
+                    vout: i.outpoint.vout,
+                },
                 input_description: i.input_description.clone(),
                 unlocking_script_length: if i.unlocking_script.is_some() {
                     i.unlocking_script.as_ref().unwrap().len()
@@ -72,10 +110,17 @@ fn to_storage_args(args: &ValidCreateActionArgs) -> StorageCreateActionArgs {
         lock_time: args.lock_time,
         version: args.version,
         labels: args.labels.iter().map(|l| l.to_string()).collect(),
+        options: storage_options,
+        input_beef: args.input_beef.clone(),
+        is_new_tx: args.is_new_tx,
+        is_sign_action: args.is_sign_action,
         is_no_send: args.is_no_send,
         is_delayed: args.is_delayed,
-        is_sign_action: args.is_sign_action,
-        input_beef: args.input_beef.clone(),
+        is_send_with: args.is_send_with,
+        is_remix_change: false,
+        is_test_werr_review_actions: None,
+        include_all_source_transactions: false,
+        random_vals: None,
     }
 }
 

--- a/src/storage/action_types.rs
+++ b/src/storage/action_types.rs
@@ -7,7 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 use bsv::wallet::interfaces::SendWithResult;
-use bsv::wallet::types::TXIDHexString;
+use bsv::wallet::types::{BooleanDefaultFalse, BooleanDefaultTrue, TXIDHexString};
 
 use crate::types::StorageProvidedBy;
 
@@ -37,12 +37,56 @@ impl Default for StorageFeeModel {
 // Create action types
 // ---------------------------------------------------------------------------
 
+/// Outpoint reference matching the TS `{ txid, vout }` wire format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageOutPoint {
+    pub txid: TXIDHexString,
+    pub vout: u32,
+}
+
+/// Options for create action, matching TS ValidCreateActionOptions wire format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageCreateActionOptions {
+    pub sign_and_process: BooleanDefaultTrue,
+    pub accept_delayed_broadcast: BooleanDefaultTrue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trust_self: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub known_txids: Vec<TXIDHexString>,
+    pub return_txid_only: BooleanDefaultFalse,
+    pub no_send: BooleanDefaultFalse,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub no_send_change: Vec<StorageOutPoint>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub send_with: Vec<TXIDHexString>,
+    pub randomize_outputs: BooleanDefaultTrue,
+}
+
+impl Default for StorageCreateActionOptions {
+    fn default() -> Self {
+        Self {
+            sign_and_process: BooleanDefaultTrue(Some(true)),
+            accept_delayed_broadcast: BooleanDefaultTrue(Some(true)),
+            trust_self: None,
+            known_txids: vec![],
+            return_txid_only: BooleanDefaultFalse(Some(false)),
+            no_send: BooleanDefaultFalse(Some(false)),
+            no_send_change: vec![],
+            send_with: vec![],
+            randomize_outputs: BooleanDefaultTrue(Some(true)),
+        }
+    }
+}
+
 /// Arguments for storage.create_action.
 ///
 /// Carries validated create action data from the signer to storage,
 /// which allocates UTXOs, creates transaction records, and returns
 /// the data needed to build the actual transaction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StorageCreateActionArgs {
     /// Human-readable description of the action.
     pub description: String,
@@ -55,24 +99,41 @@ pub struct StorageCreateActionArgs {
     /// Transaction version.
     pub version: u32,
     /// Labels to apply to this action.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub labels: Vec<String>,
+    /// Action options (signAndProcess, noSend, etc.).
+    pub options: StorageCreateActionOptions,
+    /// BEEF data for input validity proofs.
+    #[serde(rename = "inputBEEF", skip_serializing_if = "Option::is_none")]
+    pub input_beef: Option<Vec<u8>>,
+    /// True if this is a new transaction (not a sign-only operation).
+    pub is_new_tx: bool,
+    /// If true, this is a signAction (partial signing) flow.
+    pub is_sign_action: bool,
     /// If true, do not broadcast the transaction.
     pub is_no_send: bool,
     /// If true, defer broadcasting.
     pub is_delayed: bool,
-    /// If true, this is a signAction (partial signing) flow.
-    pub is_sign_action: bool,
-    /// BEEF data for input validity proofs.
-    pub input_beef: Option<Vec<u8>>,
+    /// True if this is a send-with batch operation.
+    pub is_send_with: bool,
+    /// True if this action remixes change.
+    pub is_remix_change: bool,
+    /// Test hook for werr review actions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_test_werr_review_actions: Option<bool>,
+    /// Whether to include all source transactions in BEEF.
+    pub include_all_source_transactions: bool,
+    /// Test hook: pre-determined random values for deterministic testing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub random_vals: Option<Vec<f64>>,
 }
 
 /// An input specification for storage create action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StorageCreateActionInput {
-    /// Transaction ID of the output being spent.
-    pub outpoint_txid: String,
-    /// Output index of the output being spent.
-    pub outpoint_vout: u32,
+    /// Nested outpoint reference ({ txid, vout }).
+    pub outpoint: StorageOutPoint,
     /// Human-readable description of why this input is spent.
     pub input_description: String,
     /// Expected unlocking script length for size estimation.
@@ -83,6 +144,7 @@ pub struct StorageCreateActionInput {
 
 /// An output specification for storage create action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StorageCreateActionOutput {
     /// Locking script as hex string.
     pub locking_script: String,
@@ -91,10 +153,13 @@ pub struct StorageCreateActionOutput {
     /// Human-readable output description.
     pub output_description: String,
     /// Optional basket name to categorize this output.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub basket: Option<String>,
     /// Optional custom spending instructions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_instructions: Option<String>,
     /// Tags to apply to this output.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub tags: Vec<String>,
 }
 

--- a/src/storage/methods/create_action.rs
+++ b/src/storage/methods/create_action.rs
@@ -226,8 +226,8 @@ async fn do_create_action<S: StorageReaderWriter + ?Sized>(
         let find_args = FindOutputsArgs {
             partial: OutputPartial {
                 user_id: Some(user_id),
-                txid: Some(input.outpoint_txid.clone()),
-                vout: Some(input.outpoint_vout as i32),
+                txid: Some(input.outpoint.txid.clone()),
+                vout: Some(input.outpoint.vout as i32),
                 ..Default::default()
             },
             ..Default::default()
@@ -241,7 +241,7 @@ async fn do_create_action<S: StorageReaderWriter + ?Sized>(
                     parameter: format!("inputs[{}]", vin),
                     must_be: format!(
                         "spendable output. output {}:{} is not spendable.",
-                        input.outpoint_txid, input.outpoint_vout
+                        input.outpoint.txid, input.outpoint.vout
                     ),
                 });
             }
@@ -269,8 +269,8 @@ async fn do_create_action<S: StorageReaderWriter + ?Sized>(
 
             input_records.push(StorageCreateTransactionSdkInput {
                 vin: vin as u32,
-                source_txid: input.outpoint_txid.clone(),
-                source_vout: input.outpoint_vout,
+                source_txid: input.outpoint.txid.clone(),
+                source_vout: input.outpoint.vout,
                 source_satoshis: output.satoshis as u64,
                 source_locking_script: locking_script_hex,
                 source_transaction: None,
@@ -295,8 +295,8 @@ async fn do_create_action<S: StorageReaderWriter + ?Sized>(
 
             input_records.push(StorageCreateTransactionSdkInput {
                 vin: vin as u32,
-                source_txid: input.outpoint_txid.clone(),
-                source_vout: input.outpoint_vout,
+                source_txid: input.outpoint.txid.clone(),
+                source_vout: input.outpoint.vout,
                 source_satoshis: 0,
                 source_locking_script: String::new(),
                 source_transaction: None,
@@ -628,7 +628,7 @@ async fn do_create_action<S: StorageReaderWriter + ?Sized>(
 #[cfg(feature = "sqlite")]
 mod tests {
     use super::*;
-    use crate::storage::action_types::StorageCreateActionOutput;
+    use crate::storage::action_types::{StorageCreateActionOptions, StorageCreateActionOutput};
     use crate::storage::find_args::{
         FindOutputsArgs, FindTransactionsArgs, OutputPartial, TransactionPartial,
     };
@@ -753,10 +753,17 @@ mod tests {
             lock_time: 0,
             version: 1,
             labels: vec!["test-label".to_string()],
+            options: StorageCreateActionOptions::default(),
+            input_beef: None,
+            is_new_tx: true,
+            is_sign_action: false,
             is_no_send: false,
             is_delayed: false,
-            is_sign_action: false,
-            input_beef: None,
+            is_send_with: false,
+            is_remix_change: false,
+            is_test_werr_review_actions: None,
+            include_all_source_transactions: false,
+            random_vals: None,
         };
 
         let result = storage_create_action(&storage, user_id, &args, None)
@@ -796,10 +803,17 @@ mod tests {
             lock_time: 0,
             version: 1,
             labels: vec![],
+            options: StorageCreateActionOptions::default(),
+            input_beef: None,
+            is_new_tx: true,
+            is_sign_action: false,
             is_no_send: false,
             is_delayed: false,
-            is_sign_action: false,
-            input_beef: None,
+            is_send_with: false,
+            is_remix_change: false,
+            is_test_werr_review_actions: None,
+            include_all_source_transactions: false,
+            random_vals: None,
         };
 
         let result = storage_create_action(&storage, user_id, &args, None)
@@ -842,10 +856,17 @@ mod tests {
             lock_time: 0,
             version: 1,
             labels: vec![],
+            options: StorageCreateActionOptions::default(),
+            input_beef: None,
+            is_new_tx: true,
+            is_sign_action: false,
             is_no_send: false,
             is_delayed: false,
-            is_sign_action: false,
-            input_beef: None,
+            is_send_with: false,
+            is_remix_change: false,
+            is_test_werr_review_actions: None,
+            include_all_source_transactions: false,
+            random_vals: None,
         };
 
         let result = storage_create_action(&storage, user_id, &args, None)
@@ -906,10 +927,17 @@ mod tests {
             lock_time: 0,
             version: 1,
             labels: vec![],
+            options: StorageCreateActionOptions::default(),
+            input_beef: None,
+            is_new_tx: true,
+            is_sign_action: false,
             is_no_send: false,
             is_delayed: false,
-            is_sign_action: false,
-            input_beef: None,
+            is_send_with: false,
+            is_remix_change: false,
+            is_test_werr_review_actions: None,
+            include_all_source_transactions: false,
+            random_vals: None,
         };
 
         let _result = storage_create_action(&storage, user_id, &args, None)
@@ -960,10 +988,17 @@ mod tests {
             lock_time: 0,
             version: 1,
             labels: vec![],
+            options: StorageCreateActionOptions::default(),
+            input_beef: None,
+            is_new_tx: true,
+            is_sign_action: false,
             is_no_send: false,
             is_delayed: false,
-            is_sign_action: false,
-            input_beef: None,
+            is_send_with: false,
+            is_remix_change: false,
+            is_test_werr_review_actions: None,
+            include_all_source_transactions: false,
+            random_vals: None,
         };
 
         let result = storage_create_action(&storage, user_id, &args, None)

--- a/tests/serialization_parity_tests.rs
+++ b/tests/serialization_parity_tests.rs
@@ -1,0 +1,81 @@
+use bsv_wallet_toolbox::storage::action_types::*;
+
+#[test]
+fn test_create_action_args_wire_format_matches_ts() {
+    let args = StorageCreateActionArgs {
+        description: "test payment".to_string(),
+        inputs: vec![StorageCreateActionInput {
+            outpoint: StorageOutPoint {
+                txid: "a".repeat(64),
+                vout: 0,
+            },
+            input_description: "spend utxo".to_string(),
+            unlocking_script_length: 107,
+            sequence_number: 0xffffffff,
+        }],
+        outputs: vec![StorageCreateActionOutput {
+            locking_script: "76a914aabb88ac".to_string(),
+            satoshis: 1000,
+            output_description: "payment".to_string(),
+            basket: None,
+            custom_instructions: None,
+            tags: vec![],
+        }],
+        lock_time: 0,
+        version: 1,
+        labels: vec![],
+        options: StorageCreateActionOptions::default(),
+        input_beef: Some(vec![0, 1, 2]),
+        is_new_tx: true,
+        is_sign_action: false,
+        is_no_send: false,
+        is_delayed: true,
+        is_send_with: false,
+        is_remix_change: false,
+        is_test_werr_review_actions: None,
+        include_all_source_transactions: false,
+        random_vals: None,
+    };
+    let json = serde_json::to_value(&args).unwrap();
+
+    // Verify nested outpoint object
+    let input = &json["inputs"][0];
+    assert!(
+        input.get("outpoint").is_some(),
+        "must have nested outpoint object"
+    );
+    assert_eq!(input["outpoint"]["txid"].as_str().unwrap().len(), 64);
+    assert_eq!(input["outpoint"]["vout"].as_u64().unwrap(), 0);
+    assert!(
+        input.get("outpointTxid").is_none(),
+        "flat outpointTxid must NOT appear"
+    );
+
+    // Verify options present
+    assert!(json.get("options").is_some(), "must have options object");
+    let opts = &json["options"];
+    assert!(opts.get("signAndProcess").is_some());
+    assert!(opts.get("acceptDelayedBroadcast").is_some());
+    assert!(opts.get("randomizeOutputs").is_some());
+
+    // Verify boolean flags
+    assert!(json.get("isNewTx").is_some());
+    assert!(json.get("isSendWith").is_some());
+    assert!(json.get("isDelayed").is_some());
+    assert!(json.get("isRemixChange").is_some());
+    assert!(json.get("includeAllSourceTransactions").is_some());
+
+    // Verify inputBEEF (uppercase BEEF)
+    assert!(
+        json.get("inputBEEF").is_some(),
+        "must use inputBEEF not inputBeef"
+    );
+
+    // Verify camelCase
+    assert!(json.get("lockTime").is_some());
+    assert!(json.get("isSignAction").is_some());
+    assert!(json.get("lock_time").is_none());
+
+    // Negative assertion: camelCase "inputBeef" must NOT appear (we use "inputBEEF")
+    assert!(json.get("inputBeef").is_none(), "'inputBeef' (camelCase) must not appear");
+}


### PR DESCRIPTION
## Summary\n- Adds `StorageOutPoint` struct for nested `{ txid, vout }` objects (replaces flat `outpointTxid`/`outpointVout`)\n- Adds `StorageCreateActionOptions` matching TS `ValidCreateActionOptions` (signAndProcess, acceptDelayedBroadcast, randomizeOutputs, etc.)\n- Expands `StorageCreateActionArgs` with `options`, `isNewTx`, `isSendWith`, `isRemixChange`, `includeAllSourceTransactions`, `randomVals`, `isTestWerrReviewActions`\n- Updates `to_storage_args()` to populate all new fields from `ValidCreateActionArgs`\n- Updates all storage method field access patterns (`outpoint.txid` instead of `outpointTxid`)\n- All serde attributes: `rename_all = \"camelCase\"`, `skip_serializing_if`, `rename = \"inputBEEF\"`\n\nAddresses **C3** from #2\n\n## Test plan\n- [x] Wire format test verifies nested outpoint, options, boolean flags, inputBEEF\n- [x] Negative assertions verify no snake_case or flat field leaks\n- [x] `cargo check` passes\n- [x] `cargo test` — all 406 tests pass, 0 failures"