### PR TITLE
fix(signer): merge source tx BEEF proofs in create_action

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsv-wallet-toolbox"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2021"
 rust-version = "1.87"
 description = "Pure Rust BSV wallet-toolbox implementation"

--- a/src/signer/methods/create_action.rs
+++ b/src/signer/methods/create_action.rs
@@ -146,8 +146,49 @@ pub async fn signer_create_action(
         is_active: None,
     };
     let storage_args = to_storage_args(args);
-    let dcr = storage.create_action(&auth_id, &storage_args).await?;
+    let mut dcr = storage.create_action(&auth_id, &storage_args).await?;
     let reference = dcr.reference.clone();
+
+    // Merge BEEF proof data for storage-allocated change inputs.
+    // Without this, the BEEF won't contain source tx merkle proofs
+    // and overlay hosts will reject it with SPV verification failure.
+    {
+        use bsv::transaction::beef::{Beef, BEEF_V2};
+        use crate::storage::beef::{get_valid_beef_for_txid, TrustSelf};
+
+        let active = storage.get_active().await?;
+        let mut beef = Beef::new(BEEF_V2);
+
+        if let Some(ref ib) = dcr.input_beef {
+            if !ib.is_empty() {
+                let _ = beef.merge_beef_from_binary(ib);
+            }
+        }
+
+        let known_txids = std::collections::HashSet::new();
+        for input in &dcr.inputs {
+            if input.provided_by == crate::types::StorageProvidedBy::Storage {
+                let txid = &input.source_txid;
+                if !txid.is_empty() && beef.find_txid(txid).is_none() {
+                    if let Ok(Some(tx_beef_bytes)) =
+                        get_valid_beef_for_txid(active.as_ref(), txid, TrustSelf::No, &known_txids).await
+                    {
+                        let _ = beef.merge_beef_from_binary(&tx_beef_bytes);
+                    }
+                }
+            }
+        }
+
+        if beef.txs.is_empty() {
+            dcr.input_beef = None;
+        } else {
+            let mut buf = Vec::new();
+            match beef.to_binary(&mut buf) {
+                Ok(()) => dcr.input_beef = Some(buf),
+                Err(_) => dcr.input_beef = None,
+            }
+        }
+    }
 
     // --- Step 2: Build unsigned transaction ---
     let (mut tx, amount, pdi) =

--- a/src/signer/methods/create_action.rs
+++ b/src/signer/methods/create_action.rs
@@ -147,48 +147,8 @@ pub async fn signer_create_action(
     };
     let storage_args = to_storage_args(args);
     let mut dcr = storage.create_action(&auth_id, &storage_args).await?;
+    merge_input_beef_signer(storage, &mut dcr).await?;
     let reference = dcr.reference.clone();
-
-    // Merge BEEF proof data for storage-allocated change inputs.
-    // Without this, the BEEF won't contain source tx merkle proofs
-    // and overlay hosts will reject it with SPV verification failure.
-    {
-        use bsv::transaction::beef::{Beef, BEEF_V2};
-        use crate::storage::beef::{get_valid_beef_for_txid, TrustSelf};
-
-        let active = storage.get_active().await?;
-        let mut beef = Beef::new(BEEF_V2);
-
-        if let Some(ref ib) = dcr.input_beef {
-            if !ib.is_empty() {
-                let _ = beef.merge_beef_from_binary(ib);
-            }
-        }
-
-        let known_txids = std::collections::HashSet::new();
-        for input in &dcr.inputs {
-            if input.provided_by == crate::types::StorageProvidedBy::Storage {
-                let txid = &input.source_txid;
-                if !txid.is_empty() && beef.find_txid(txid).is_none() {
-                    if let Ok(Some(tx_beef_bytes)) =
-                        get_valid_beef_for_txid(active.as_ref(), txid, TrustSelf::No, &known_txids).await
-                    {
-                        let _ = beef.merge_beef_from_binary(&tx_beef_bytes);
-                    }
-                }
-            }
-        }
-
-        if beef.txs.is_empty() {
-            dcr.input_beef = None;
-        } else {
-            let mut buf = Vec::new();
-            match beef.to_binary(&mut buf) {
-                Ok(()) => dcr.input_beef = Some(buf),
-                Err(_) => dcr.input_beef = None,
-            }
-        }
-    }
 
     // --- Step 2: Build unsigned transaction ---
     let (mut tx, amount, pdi) =
@@ -410,6 +370,124 @@ pub(crate) fn build_beef_bytes(
         .map_err(|e| WalletError::Internal(format!("Failed to compute txid: {}", e)))?;
     let beef = build_beef(tx, input_beef)?;
     serialize_beef_atomic(&beef, &txid)
+}
+
+/// Populate `dcr.input_beef` with BEEF proof data for all storage-provided inputs.
+///
+/// Without this, the outgoing BEEF won't include source tx proofs and
+/// recipients/miners will reject it during SPV verification.
+///
+/// Also merges any stored `inputBEEF` from source transactions (which may
+/// contain the original sender's BEEF chain, needed for full verification
+/// when our UTXOs came from received payments).
+async fn merge_input_beef_signer(
+    storage: &WalletStorageManager,
+    dcr: &mut crate::storage::action_types::StorageCreateActionResult,
+) -> WalletResult<()> {
+    use std::collections::HashSet;
+    use bsv::transaction::beef::{Beef, BEEF_V2};
+    use crate::storage::beef::{get_valid_beef_for_txid, TrustSelf};
+    use crate::types::StorageProvidedBy;
+
+    let active = match storage.active() {
+        Some(a) => a.clone(),
+        None => return Ok(()),
+    };
+
+    let mut beef = Beef::new(BEEF_V2);
+
+    // Merge the base input_beef from storage — this is the foundation.
+    if let Some(ref ib) = dcr.input_beef {
+        if !ib.is_empty() {
+            beef.merge_beef_from_binary(ib).map_err(|e| {
+                WalletError::Internal(format!(
+                    "Failed to merge base input BEEF ({} bytes): {e}", ib.len()
+                ))
+            })?;
+        }
+    }
+
+    // Merge BEEF for each storage-provided input
+    let mut known_txids: HashSet<String> = HashSet::new();
+    for input in &dcr.inputs {
+        if input.provided_by == StorageProvidedBy::Storage {
+            let txid = &input.source_txid;
+            if !txid.is_empty() && beef.find_txid(txid).is_none() {
+                let tx_beef_bytes = get_valid_beef_for_txid(
+                    &*active, txid, TrustSelf::No, &known_txids,
+                )
+                .await
+                .map_err(|e| {
+                    WalletError::Internal(format!(
+                        "Failed to fetch BEEF for storage input {txid}: {e}"
+                    ))
+                })?
+                .ok_or_else(|| {
+                    WalletError::Internal(format!(
+                        "No BEEF proof found for storage-provided input {txid}"
+                    ))
+                })?;
+
+                beef.merge_beef_from_binary(&tx_beef_bytes).map_err(|e| {
+                    WalletError::Internal(format!(
+                        "Failed to merge BEEF for input {txid}: {e}"
+                    ))
+                })?;
+
+                known_txids.insert(txid.clone());
+            }
+        }
+    }
+
+    // Merge any stored inputBEEF from source transactions.
+    // When UTXOs came from received payments, the sender's proof chain
+    // is stored as inputBEEF on the source transaction record.
+    for input in &dcr.inputs {
+        if input.provided_by == StorageProvidedBy::Storage && !input.source_txid.is_empty() {
+            let txs = active
+                .find_transactions(&crate::storage::find_args::FindTransactionsArgs {
+                    partial: crate::storage::find_args::TransactionPartial {
+                        txid: Some(input.source_txid.clone()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .await
+                .map_err(|e| {
+                    WalletError::Internal(format!(
+                        "Failed to look up source tx {}: {e}", input.source_txid
+                    ))
+                })?;
+
+            for tx_rec in &txs {
+                if let Some(ref ib) = tx_rec.input_beef {
+                    if !ib.is_empty() {
+                        beef.merge_beef_from_binary(ib).map_err(|e| {
+                            WalletError::Internal(format!(
+                                "Failed to merge stored inputBEEF for {}: {e}",
+                                input.source_txid
+                            ))
+                        })?;
+                    }
+                }
+            }
+        }
+    }
+
+    // Serialize back
+    if beef.txs.is_empty() {
+        dcr.input_beef = None;
+    } else {
+        let mut buf = Vec::new();
+        beef.to_binary(&mut buf).map_err(|e| {
+            WalletError::Internal(format!(
+                "Failed to serialize merged BEEF ({} txs): {e}", beef.txs.len()
+            ))
+        })?;
+        dcr.input_beef = Some(buf);
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`merge_input_beef` was defined but never called in the signer's `create_action` flow. When the wallet auto-selected UTXOs for funding, the resulting BEEF contained no source tx merkle proofs, causing overlay hosts to reject transactions with:

> "Verification failed because the input at index 0 is missing an associated source transaction"

Now fetches proven tx BEEF data for all storage-allocated inputs via `get_valid_beef_for_txid` and merges it into `dcr.input_beef` before building the final BEEF.

## Test plan
- [x] `cargo build` passes
- [x] Live test: coordinator `anoint_host` now succeeds — overlay accepts the BEEF with valid SPV proofs
- [x] Verified `anointed: true` on coordinator status endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)