### PR TITLE
fix(beef): merge stored inputBEEF during recursive BEEF construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.21] - 2026-04-15
+
+### Fixed
+
+- **Recursive BEEF inputBEEF merging** — `collect_tx_recursive` and
+  `collect_tx_recursive_reader` now merge stored `inputBEEF` from transaction
+  records during recursive BEEF construction. Previously, ancestor proof chains
+  stored on intermediate transactions (e.g. from received PeerPay payments) were
+  lost at recursion depth > 1, producing incomplete BEEF in rapid-spend scenarios.
+  This matches the TS SDK's `StorageProvider.getValidBeefForTxid` behavior where
+  `beef.mergeBeef(r.inputBEEF)` is called at every recursion level.
+
 ## [0.2.19] - 2026-04-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsv-wallet-toolbox"
-version = "0.2.20"
+version = "0.2.21"
 edition = "2021"
 rust-version = "1.87"
 description = "Pure Rust BSV wallet-toolbox implementation"

--- a/src/storage/beef.rs
+++ b/src/storage/beef.rs
@@ -39,6 +39,8 @@ struct CollectedTx {
     merkle_path: Option<Vec<u8>>,
     /// Whether this is a txid-only entry (trusted, no raw_tx needed in BEEF).
     txid_only: bool,
+    /// Stored inputBEEF from the transaction record (ancestor proof chain).
+    input_beef: Option<Vec<u8>>,
 }
 
 /// Build a valid BEEF for the given txid by recursively walking input chains.
@@ -141,6 +143,7 @@ async fn collect_tx_recursive(
                 txid: txid.to_string(),
                 merkle_path: None,
                 txid_only: true,
+                input_beef: None,
             });
         } else {
             collected.push(CollectedTx {
@@ -148,6 +151,7 @@ async fn collect_tx_recursive(
                 txid: txid.to_string(),
                 merkle_path: Some(ptx.merkle_path),
                 txid_only: false,
+                input_beef: None,
             });
         }
         return Ok(());
@@ -174,6 +178,7 @@ async fn collect_tx_recursive(
                     txid: txid.to_string(),
                     merkle_path: None,
                     txid_only: true,
+                    input_beef: None,
                 });
             }
             return Ok(());
@@ -187,6 +192,7 @@ async fn collect_tx_recursive(
             txid: txid.to_string(),
             merkle_path: None,
             txid_only: true,
+            input_beef: None,
         });
         return Ok(());
     }
@@ -202,11 +208,15 @@ async fn collect_tx_recursive(
                     txid: txid.to_string(),
                     merkle_path: None,
                     txid_only: true,
+                    input_beef: None,
                 });
             }
             return Ok(());
         }
     };
+
+    // Extract stored inputBEEF before consuming tx_record
+    let stored_input_beef = tx_record.input_beef.filter(|ib| !ib.is_empty());
 
     // Parse raw_tx to extract input txids for recursion
     let bsv_tx = {
@@ -228,6 +238,7 @@ async fn collect_tx_recursive(
                         txid: source_txid.clone(),
                         merkle_path: None,
                         txid_only: true,
+                        input_beef: None,
                     });
                 } else {
                     Box::pin(collect_tx_recursive(
@@ -245,12 +256,13 @@ async fn collect_tx_recursive(
     }
 
     // Add this transaction (not proven, with raw_tx, no merkle proof)
-    // Also merge inputBEEF if available
+    // Include stored inputBEEF so ancestor proof chains are preserved
     collected.push(CollectedTx {
         raw_tx,
         txid: txid.to_string(),
         merkle_path: None,
         txid_only: false,
+        input_beef: stored_input_beef,
     });
 
     Ok(())
@@ -303,6 +315,16 @@ fn build_beef_from_collected(collected: Vec<CollectedTx>) -> WalletResult<Option
             WalletError::Internal(format!("Failed to create BeefTx for {}: {}", ctx.txid, e))
         })?;
         beef.txs.push(beef_tx);
+
+        // Merge stored inputBEEF (ancestor proof chains from received payments)
+        if let Some(ref ib) = ctx.input_beef {
+            beef.merge_beef_from_binary(ib).map_err(|e| {
+                WalletError::Internal(format!(
+                    "Failed to merge stored inputBEEF for {}: {}",
+                    ctx.txid, e
+                ))
+            })?;
+        }
     }
 
     let mut buf = Vec::new();
@@ -350,6 +372,7 @@ async fn collect_tx_recursive_reader<S: StorageReader + ?Sized>(
                 txid: txid.to_string(),
                 merkle_path: None,
                 txid_only: true,
+                input_beef: None,
             });
         } else {
             collected.push(CollectedTx {
@@ -357,6 +380,7 @@ async fn collect_tx_recursive_reader<S: StorageReader + ?Sized>(
                 txid: txid.to_string(),
                 merkle_path: Some(ptx.merkle_path),
                 txid_only: false,
+                input_beef: None,
             });
         }
         return Ok(());
@@ -385,6 +409,7 @@ async fn collect_tx_recursive_reader<S: StorageReader + ?Sized>(
                     txid: txid.to_string(),
                     merkle_path: None,
                     txid_only: true,
+                    input_beef: None,
                 });
             }
             return Ok(());
@@ -397,6 +422,7 @@ async fn collect_tx_recursive_reader<S: StorageReader + ?Sized>(
             txid: txid.to_string(),
             merkle_path: None,
             txid_only: true,
+            input_beef: None,
         });
         return Ok(());
     }
@@ -410,11 +436,15 @@ async fn collect_tx_recursive_reader<S: StorageReader + ?Sized>(
                     txid: txid.to_string(),
                     merkle_path: None,
                     txid_only: true,
+                    input_beef: None,
                 });
             }
             return Ok(());
         }
     };
+
+    // Extract stored inputBEEF before consuming tx_record
+    let stored_input_beef = tx_record.input_beef.filter(|ib| !ib.is_empty());
 
     let bsv_tx = {
         let mut cursor = Cursor::new(&raw_tx);
@@ -433,6 +463,7 @@ async fn collect_tx_recursive_reader<S: StorageReader + ?Sized>(
                         txid: source_txid.clone(),
                         merkle_path: None,
                         txid_only: true,
+                        input_beef: None,
                     });
                 } else {
                     Box::pin(collect_tx_recursive_reader(
@@ -449,11 +480,13 @@ async fn collect_tx_recursive_reader<S: StorageReader + ?Sized>(
         }
     }
 
+    // Include stored inputBEEF so ancestor proof chains are preserved
     collected.push(CollectedTx {
         raw_tx,
         txid: txid.to_string(),
         merkle_path: None,
         txid_only: false,
+        input_beef: stored_input_beef,
     });
 
     Ok(())

--- a/src/storage/beef.rs
+++ b/src/storage/beef.rs
@@ -39,7 +39,7 @@ struct CollectedTx {
     merkle_path: Option<Vec<u8>>,
     /// Whether this is a txid-only entry (trusted, no raw_tx needed in BEEF).
     txid_only: bool,
-    /// Stored inputBEEF from the transaction record (ancestor proof chain).
+    /// Stored inputBEEF from the transaction record (serialized BEEF containing ancestor proofs).
     input_beef: Option<Vec<u8>>,
 }
 
@@ -215,7 +215,7 @@ async fn collect_tx_recursive(
         }
     };
 
-    // Extract stored inputBEEF before consuming tx_record
+    // Extract stored inputBEEF, filtering out empty values
     let stored_input_beef = tx_record.input_beef.filter(|ib| !ib.is_empty());
 
     // Parse raw_tx to extract input txids for recursion
@@ -316,7 +316,7 @@ fn build_beef_from_collected(collected: Vec<CollectedTx>) -> WalletResult<Option
         })?;
         beef.txs.push(beef_tx);
 
-        // Merge stored inputBEEF (ancestor proof chains from received payments)
+        // Merge stored inputBEEF (ancestor proof chains for this transaction's inputs)
         if let Some(ref ib) = ctx.input_beef {
             beef.merge_beef_from_binary(ib).map_err(|e| {
                 WalletError::Internal(format!(
@@ -443,7 +443,7 @@ async fn collect_tx_recursive_reader<S: StorageReader + ?Sized>(
         }
     };
 
-    // Extract stored inputBEEF before consuming tx_record
+    // Extract stored inputBEEF, filtering out empty values
     let stored_input_beef = tx_record.input_beef.filter(|ib| !ib.is_empty());
 
     let bsv_tx = {

--- a/tests/beef_tests.rs
+++ b/tests/beef_tests.rs
@@ -152,7 +152,95 @@ mod beef_tests {
     }
 
     // -----------------------------------------------------------------------
-    // Test 4: Transaction without raw_tx and not in known_txids returns None
+    // Test 4: Transaction with input_beef merges ancestor proofs into output
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_beef_input_beef_is_merged_into_output() {
+        use bsv::transaction::beef::{Beef, BEEF_V2};
+        use bsv::transaction::beef_tx::BeefTx;
+        use bsv::transaction::transaction::Transaction as BsvTransaction;
+        use std::io::Cursor;
+
+        let storage = setup_storage().await.unwrap();
+        let user_id = insert_test_user(&storage, "02beef05").await;
+        let now = dt("2024-01-15 11:00:00");
+
+        // Build a minimal valid BEEF to serve as the stored inputBEEF.
+        // It contains TXID_A as a txid-only entry — simulating an ancestor proof chain.
+        let ancestor_beef_bytes = {
+            let mut beef = Beef::new(BEEF_V2);
+            let beef_tx = BeefTx::from_txid(TXID_A.to_string());
+            beef.txs.push(beef_tx);
+            let mut buf = Vec::new();
+            beef.to_binary(&mut buf).expect("BEEF serialization");
+            buf
+        };
+
+        // Minimal valid raw_tx (version + 0 inputs + 0 outputs + locktime).
+        // This parses successfully and has no inputs, so no recursion occurs.
+        let minimal_raw_tx = vec![
+            0x01, 0x00, 0x00, 0x00, // version 1
+            0x00, // 0 inputs
+            0x00, // 0 outputs
+            0x00, 0x00, 0x00, 0x00, // locktime 0
+        ];
+
+        // Compute the txid of our minimal raw_tx
+        let txid_c = {
+            let bsv_tx = BsvTransaction::from_binary(&mut Cursor::new(&minimal_raw_tx)).unwrap();
+            bsv_tx.id().expect("txid")
+        };
+
+        // Insert a Transaction with raw_tx and input_beef populated
+        let tx = Transaction {
+            created_at: now,
+            updated_at: now,
+            transaction_id: 0,
+            user_id,
+            proven_tx_id: None,
+            status: TransactionStatus::Completed,
+            reference: "ref-input-beef".to_string(),
+            is_outgoing: true,
+            satoshis: 1000,
+            description: "tx with inputBEEF".to_string(),
+            version: Some(1),
+            lock_time: Some(0),
+            txid: Some(txid_c.clone()),
+            input_beef: Some(ancestor_beef_bytes),
+            raw_tx: Some(minimal_raw_tx),
+        };
+        storage.insert_transaction(&tx, None).await.unwrap();
+
+        let known_txids = HashSet::new();
+        let result = get_valid_beef_for_txid(&storage, &txid_c, TrustSelf::No, &known_txids)
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_some(),
+            "should produce BEEF for tx with inputBEEF"
+        );
+
+        // Deserialize the output BEEF and verify TXID_A from the inputBEEF was merged in
+        let output_bytes = result.unwrap();
+        let parsed = Beef::from_binary(&mut Cursor::new(&output_bytes))
+            .expect("output BEEF should be parseable");
+
+        let txids: Vec<&str> = parsed.txs.iter().map(|t| t.txid.as_str()).collect();
+        assert!(
+            txids.contains(&TXID_A),
+            "output BEEF should contain TXID_A from merged inputBEEF, got: {:?}",
+            txids
+        );
+        assert!(
+            txids.contains(&txid_c.as_str()),
+            "output BEEF should contain the main transaction txid"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 5: Transaction without raw_tx and not in known_txids returns None
     // -----------------------------------------------------------------------
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Fixes `collect_tx_recursive` and `collect_tx_recursive_reader` to merge stored `inputBEEF` from transaction records during recursive BEEF construction
- Adds `input_beef: Option<Vec<u8>>` field to `CollectedTx` struct to carry ancestor proof chains through collection
- Merges stored `inputBEEF` in `build_beef_from_collected` via `beef.merge_beef_from_binary()` — matches TS SDK's `StorageProvider.getValidBeefForTxid` where `beef.mergeBeef(r.inputBEEF)` is called at every recursion level
- Bumps version to 0.2.21

Closes #20

## Context

When a PeerPay payment is received, the sender's BEEF chain is stored as `inputBEEF` on the transaction record. Previously, `collect_tx_recursive` would take `raw_tx` and recurse into source txids but never read `tx_record.input_beef`. This meant ancestor proof chains were lost at recursion depth > 1, producing incomplete BEEF in rapid-spend scenarios (multiple spends within the same block window).

## Test plan

- [x] All 4 existing `beef_tests` pass (no regressions)
- [x] `cargo check` clean (no new warnings)
- [ ] Manual verification with multi-hop unproven chain (rapid PeerPay → spend → spend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)