### PR TITLE
fix: eliminate silent failures in merge_input_beef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.22] - 2026-04-15
+
+### Fixed
+
+- **`merge_input_beef` silent failure elimination** — Changed return type from
+  `()` to `WalletResult<()>` and replaced `let _ =` error suppression with
+  proper `map_err()?` propagation. Previously, corrupt or malformed BEEF data
+  would be silently swallowed, producing incomplete BEEF with no diagnostics.
+  Affects caller-provided inputBEEF merge, storage-input BEEF merge, and BEEF
+  serialization. **Breaking:** callers must now handle the `WalletResult`.
+
+- **`wallet.rs` BeefParty merge logging** — Replaced `let _ =` with
+  `log::warn!` on `merge_beef` failure so merge errors are observable.
+
 ## [0.2.21] - 2026-04-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsv-wallet-toolbox"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 rust-version = "1.87"
 description = "Pure Rust BSV wallet-toolbox implementation"

--- a/src/signer/methods/create_action.rs
+++ b/src/signer/methods/create_action.rs
@@ -384,10 +384,10 @@ async fn merge_input_beef_signer(
     storage: &WalletStorageManager,
     dcr: &mut crate::storage::action_types::StorageCreateActionResult,
 ) -> WalletResult<()> {
-    use std::collections::HashSet;
-    use bsv::transaction::beef::{Beef, BEEF_V2};
     use crate::storage::beef::{get_valid_beef_for_txid, TrustSelf};
     use crate::types::StorageProvidedBy;
+    use bsv::transaction::beef::{Beef, BEEF_V2};
+    use std::collections::HashSet;
 
     let active = match storage.active() {
         Some(a) => a.clone(),
@@ -401,7 +401,8 @@ async fn merge_input_beef_signer(
         if !ib.is_empty() {
             beef.merge_beef_from_binary(ib).map_err(|e| {
                 WalletError::Internal(format!(
-                    "Failed to merge base input BEEF ({} bytes): {e}", ib.len()
+                    "Failed to merge base input BEEF ({} bytes): {e}",
+                    ib.len()
                 ))
             })?;
         }
@@ -413,25 +414,22 @@ async fn merge_input_beef_signer(
         if input.provided_by == StorageProvidedBy::Storage {
             let txid = &input.source_txid;
             if !txid.is_empty() && beef.find_txid(txid).is_none() {
-                let tx_beef_bytes = get_valid_beef_for_txid(
-                    &*active, txid, TrustSelf::No, &known_txids,
-                )
-                .await
-                .map_err(|e| {
-                    WalletError::Internal(format!(
-                        "Failed to fetch BEEF for storage input {txid}: {e}"
-                    ))
-                })?
-                .ok_or_else(|| {
-                    WalletError::Internal(format!(
-                        "No BEEF proof found for storage-provided input {txid}"
-                    ))
-                })?;
+                let tx_beef_bytes =
+                    get_valid_beef_for_txid(&*active, txid, TrustSelf::No, &known_txids)
+                        .await
+                        .map_err(|e| {
+                            WalletError::Internal(format!(
+                                "Failed to fetch BEEF for storage input {txid}: {e}"
+                            ))
+                        })?
+                        .ok_or_else(|| {
+                            WalletError::Internal(format!(
+                                "No BEEF proof found for storage-provided input {txid}"
+                            ))
+                        })?;
 
                 beef.merge_beef_from_binary(&tx_beef_bytes).map_err(|e| {
-                    WalletError::Internal(format!(
-                        "Failed to merge BEEF for input {txid}: {e}"
-                    ))
+                    WalletError::Internal(format!("Failed to merge BEEF for input {txid}: {e}"))
                 })?;
 
                 known_txids.insert(txid.clone());
@@ -455,7 +453,8 @@ async fn merge_input_beef_signer(
                 .await
                 .map_err(|e| {
                     WalletError::Internal(format!(
-                        "Failed to look up source tx {}: {e}", input.source_txid
+                        "Failed to look up source tx {}: {e}",
+                        input.source_txid
                     ))
                 })?;
 
@@ -481,7 +480,8 @@ async fn merge_input_beef_signer(
         let mut buf = Vec::new();
         beef.to_binary(&mut buf).map_err(|e| {
             WalletError::Internal(format!(
-                "Failed to serialize merged BEEF ({} txs): {e}", beef.txs.len()
+                "Failed to serialize merged BEEF ({} txs): {e}",
+                beef.txs.len()
             ))
         })?;
         dcr.input_beef = Some(buf);

--- a/src/storage/methods/create_action.rs
+++ b/src/storage/methods/create_action.rs
@@ -124,7 +124,7 @@ pub async fn storage_create_action<S: StorageReaderWriter + ?Sized>(
 pub async fn merge_input_beef(
     storage: &dyn StorageProvider,
     result: &mut StorageCreateActionResult,
-) {
+) -> WalletResult<()> {
     use bsv::transaction::beef::{Beef, BEEF_V2};
 
     let mut beef = Beef::new(BEEF_V2);
@@ -132,7 +132,12 @@ pub async fn merge_input_beef(
     // Merge caller-provided input_beef first (if any)
     if let Some(ref ib) = result.input_beef {
         if !ib.is_empty() {
-            let _ = beef.merge_beef_from_binary(ib);
+            beef.merge_beef_from_binary(ib).map_err(|e| {
+                WalletError::Internal(format!(
+                    "Failed to merge caller-provided inputBEEF ({} bytes): {e}",
+                    ib.len()
+                ))
+            })?;
         }
     }
 
@@ -148,7 +153,11 @@ pub async fn merge_input_beef(
                     get_valid_beef_for_storage_reader(storage, txid, TrustSelf::No, &known_txids)
                         .await
                 {
-                    let _ = beef.merge_beef_from_binary(&tx_beef_bytes);
+                    beef.merge_beef_from_binary(&tx_beef_bytes).map_err(|e| {
+                        WalletError::Internal(format!(
+                            "Failed to merge BEEF for storage input {txid}: {e}"
+                        ))
+                    })?;
                 }
             }
         }
@@ -159,11 +168,16 @@ pub async fn merge_input_beef(
         result.input_beef = None;
     } else {
         let mut buf = Vec::new();
-        match beef.to_binary(&mut buf) {
-            Ok(()) => result.input_beef = Some(buf),
-            Err(_) => result.input_beef = None,
-        }
+        beef.to_binary(&mut buf).map_err(|e| {
+            WalletError::Internal(format!(
+                "Failed to serialize merged BEEF ({} txs): {e}",
+                beef.txs.len()
+            ))
+        })?;
+        result.input_beef = Some(buf);
     }
+
+    Ok(())
 }
 
 /// Inner function that does all the work within the db transaction.

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -994,7 +994,9 @@ impl WalletInterface for Wallet {
             if let Ok(beef) =
                 bsv::transaction::beef::Beef::from_binary(&mut std::io::Cursor::new(tx_bytes))
             {
-                let _ = beef_lock.beef.merge_beef(&beef);
+                if let Err(e) = beef_lock.beef.merge_beef(&beef) {
+                    tracing::warn!("BeefParty merge failed: {e}");
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Changes `merge_input_beef` return type from `()` to `WalletResult<()>` with proper `map_err()?` error propagation on all three failure points (caller inputBEEF merge, storage-input BEEF merge, BEEF serialization)
- Replaces `let _ =` in `wallet.rs` BeefParty merge with `tracing::warn!` for observability
- Bumps version to 0.2.22

Closes #22

## Context

Identified during PR #21 review. The signer's `merge_input_beef_signer` already handles errors correctly — this brings the storage version up to the same standard. Previously, corrupt or malformed BEEF data was silently swallowed, producing incomplete BEEF with no diagnostics.

## Test plan

- [x] All existing tests pass (`cargo test --features sqlite` — 0 failures)
- [x] `cargo clippy --all-features` clean (no new warnings)
- [x] `cargo fmt -- --check` clean
- [x] **Breaking change noted**: `merge_input_beef` callers must now handle `WalletResult`

🤖 Generated with [Claude Code](https://claude.com/claude-code)