### PR TITLE
feat: add SigningProvider::prepare_spend_contexts hook (0.2.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.24]
+
+### Added
+- `SigningProvider::prepare_spend_contexts` — a defaulted (no-op) hook invoked on the inline create-action signing path before signing, giving providers the unsigned transaction and per-input prevout data so they can capture per-input spend context (used by MPC cosigner integrations to bind signatures to the transaction). Backward compatible; existing implementors inherit the default.
+
 ## [0.2.23] - 2026-04-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsv-wallet-toolbox"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 rust-version = "1.87"
 description = "Pure Rust BSV wallet-toolbox implementation"

--- a/src/signer/methods/create_action_provider.rs
+++ b/src/signer/methods/create_action_provider.rs
@@ -102,6 +102,9 @@ pub async fn signer_create_action_with_provider(
         return Ok((result, Some(pending)));
     }
 
+    // Step 3a: Let the provider capture per-input spend context (no-op by default).
+    provider.prepare_spend_contexts(&tx, &pdi).await?;
+
     // Step 3b: Immediate signing via provider
     let signed_tx_bytes =
         complete_signed_transaction_with_provider(&mut tx, &pdi, &HashMap::new(), provider).await?;

--- a/src/signer/signing_provider.rs
+++ b/src/signer/signing_provider.rs
@@ -6,8 +6,10 @@
 
 use async_trait::async_trait;
 use bsv::primitives::public_key::PublicKey;
+use bsv::transaction::transaction::Transaction;
 
 use crate::error::WalletResult;
+use crate::signer::types::PendingStorageInput;
 
 /// Async trait for pluggable signing backends.
 ///
@@ -114,6 +116,19 @@ pub trait SigningProvider: Send + Sync {
         derivation_suffix: &str,
         unlocker_pub_key: &PublicKey,
     ) -> WalletResult<Vec<u8>>;
+
+    /// Hook invoked after a signable transaction is built and before inline
+    /// signing, providing the full unsigned transaction and its per-input
+    /// prevout data (`pending_inputs`). Implementations that bind signatures to
+    /// the transaction (for example MPC cosigners) can use this to capture
+    /// per-input spend context keyed by sighash. Defaults to a no-op.
+    async fn prepare_spend_contexts(
+        &self,
+        _tx: &Transaction,
+        _pending_inputs: &[PendingStorageInput],
+    ) -> WalletResult<()> {
+        Ok(())
+    }
 
     /// Get the wallet's identity public key.
     fn identity_public_key(&self) -> &PublicKey;


### PR DESCRIPTION
## Summary

Adds a **defaulted, backward-compatible** hook to the `SigningProvider` trait so providers can capture per-input spend context before inline signing.

`signer_create_action_with_provider`, on the immediate-signing path, now calls `provider.prepare_spend_contexts(&tx, &pdi)` right before `complete_signed_transaction_with_provider`, handing the provider the unsigned transaction and its per-input prevout data (`Vec<PendingStorageInput>`). The default implementation is a no-op, so the sole existing implementor (`StandardSigningProvider`) and all downstream consumers are unaffected.

### Why
An MPC cosigner integration needs to bind each partial signature to the transaction it signs. The cosigner recomputes the sighash from transmitted tx data and refuses to sign an unverifiable hash. The deferred `create → signAction` flow already exposes the unsigned tx + pdi to the caller, but the one-shot `createAction(signAndProcess:true)` path signs internally with no hook — so the MPC provider had no way to capture context for it. This hook closes that gap uniformly.

## Changes
- `src/signer/signing_provider.rs` — new defaulted `async fn prepare_spend_contexts(&self, _tx: &Transaction, _pending_inputs: &[PendingStorageInput]) -> WalletResult<()>` (no-op default).
- `src/signer/methods/create_action_provider.rs` — call the hook on the inline-sign path before signing.
- `Cargo.toml` — 0.2.23 → 0.2.24.
- `CHANGELOG.md` — `## [0.2.24]` entry.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings -A missing_docs -A clippy::missing_docs_in_private_items`
- [x] `RUSTDOCFLAGS="-D warnings -A missing_docs" cargo doc --no-deps --all-features`
- [x] `cargo build --all-targets` (tests + examples still compile; `StandardSigningProvider` inherits the default)
- [x] `cargo test --lib` — 393 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)