### PR TITLE
fix(auth): wire real UMP 2-of-3 auth into complete_auth (TS parity)

### DIFF
--- a/src/auth_manager/cwi_logic.rs
+++ b/src/auth_manager/cwi_logic.rs
@@ -45,6 +45,31 @@ pub fn derive_key_from_password(password: &[u8], salt: &[u8], iterations: u32) -
     pbkdf2_hmac_sha512(password, salt, iterations, 64)
 }
 
+/// Number of output bytes for the UMP "password key" factor.
+///
+/// The password key must be exactly 32 bytes so it can be XORed against the
+/// (32-byte) presentation key and (32-byte) recovery key, and so the XOR
+/// result is a valid AES-256 `SymmetricKey`.
+pub const UMP_PASSWORD_KEY_SIZE: usize = 32;
+
+/// Derive the UMP **password key** factor from a password and salt.
+///
+/// This is `PBKDF2(password, salt, 7777, 32, 'sha512')`, matching the
+/// deployed `paragon-wab` / CWI UMP design: a 32-byte output so it is the
+/// same length as the presentation key and recovery key factors and can be
+/// XORed with either one to unlock a `UMPToken` primary-key slot.
+///
+/// This is distinct from [`derive_key_from_password`] (a more general
+/// 64-byte derivation) — the UMP threshold scheme specifically needs a
+/// 32-byte factor.
+///
+/// # Arguments
+/// * `password` - Raw password bytes
+/// * `salt` - PBKDF2 salt (the UMP token's `password_salt` field)
+pub fn derive_password_key(password: &[u8], salt: &[u8]) -> Vec<u8> {
+    pbkdf2_hmac_sha512(password, salt, PBKDF2_NUM_ROUNDS, UMP_PASSWORD_KEY_SIZE)
+}
+
 /// XOR two byte arrays of equal length.
 ///
 /// Used for combining password-derived key with presentation key or recovery key
@@ -321,6 +346,46 @@ mod tests {
         // XOR with zeros is identity
         let z = vec![0x00, 0x00, 0x00, 0x00];
         assert_eq!(xor_keys(&a, &z), a);
+    }
+
+    #[test]
+    fn test_derive_password_key_is_32_bytes() {
+        let password = b"correct horse battery staple";
+        let salt = b"some-ump-salt-32-bytes-of-noise";
+        let key = derive_password_key(password, salt);
+        assert_eq!(
+            key.len(),
+            UMP_PASSWORD_KEY_SIZE,
+            "UMP password key must be 32 bytes to XOR against presentation/recovery keys"
+        );
+    }
+
+    #[test]
+    fn test_derive_password_key_deterministic_and_salt_sensitive() {
+        let password = b"correct horse battery staple";
+        let salt_a = b"salt-a-000000000000000000000000";
+        let salt_b = b"salt-b-000000000000000000000000";
+
+        let key_a1 = derive_password_key(password, salt_a);
+        let key_a2 = derive_password_key(password, salt_a);
+        assert_eq!(
+            key_a1, key_a2,
+            "same password+salt must derive the same key"
+        );
+
+        let key_b = derive_password_key(password, salt_b);
+        assert_ne!(key_a1, key_b, "different salt must derive a different key");
+    }
+
+    #[test]
+    fn test_derive_password_key_wrong_password_differs() {
+        let salt = b"fixed-salt-0000000000000000000000";
+        let right = derive_password_key(b"the-real-password", salt);
+        let wrong = derive_password_key(b"not-the-real-password", salt);
+        assert_ne!(
+            right, wrong,
+            "a different password must derive a different key"
+        );
     }
 
     #[test]

--- a/src/auth_manager/mod.rs
+++ b/src/auth_manager/mod.rs
@@ -43,7 +43,8 @@ use crate::wab_client::types::{FaucetResponse, StartAuthResponse};
 use crate::wab_client::WABClient;
 use crate::WalletError;
 
-use types::{AuthState, StateSnapshot, WalletBuilderFn};
+use types::{AuthState, CompleteAuthOutcome, SecondFactor, StateSnapshot, WalletBuilderFn};
+use ump_token::{AuthFactors, UMPToken};
 
 /// Macro to delegate a WalletInterface method to the inner wallet, or return
 /// `WERR_NOT_ACTIVE` if no inner wallet is available (pre-authentication).
@@ -184,21 +185,39 @@ impl WalletAuthenticationManager {
     /// Complete the WAB authentication flow.
     ///
     /// On success:
-    /// 1. Retrieves final presentation key from WAB
-    /// 2. Looks up UMP token to determine new vs existing user
-    /// 3. Derives root key from presentation key
-    /// 4. Constructs inner wallet via wallet_builder
-    /// 5. Optionally redeems faucet for new users
-    /// 6. Signals authentication completion
+    /// 1. Retrieves final presentation key from WAB (the WAB never sees the
+    ///    password or recovery key — it only ever holds the presentation-key
+    ///    factor, so it can never reconstruct a wallet key on its own).
+    /// 2. Resolves the `rootPrimaryKey` via the real UMP 2-of-3 threshold
+    ///    scheme: for a new user (no `existing_ump_token`), builds a fresh
+    ///    `UMPToken` from presentation + password + a freshly generated
+    ///    recovery key; for a returning user, decrypts the existing token
+    ///    using presentation + password (or presentation + recovery).
+    /// 3. Constructs inner wallet via `wallet_builder` using the real root key.
+    /// 4. For new users, publishes the freshly built `UMPToken` on-chain.
+    /// 5. Signals authentication completion.
+    ///
+    /// Discovering `existing_ump_token` (looking up the on-chain token by
+    /// `presentationHash`) is the caller's responsibility — it requires a
+    /// public overlay lookup that is independent of any specific wallet's
+    /// local storage (see [`ump_token::lookup_ump_token`] and the module
+    /// docs there). Pass `None` for first-time signup.
     ///
     /// # Arguments
     /// * `interactor` - The auth method interactor
     /// * `payload` - Verification payload (e.g., SMS code)
+    /// * `second_factor` - The password (new signup or returning login) or
+    ///   recovery key the caller supplies, alongside the WAB-issued
+    ///   presentation key
+    /// * `existing_ump_token` - The on-chain `UMPToken` for this user, if
+    ///   the caller already looked one up; `None` for new-user signup
     pub async fn complete_auth(
         &self,
         interactor: &dyn AuthMethodInteractor,
         payload: serde_json::Value,
-    ) -> Result<(), WalletError> {
+        second_factor: SecondFactor,
+        existing_ump_token: Option<UMPToken>,
+    ) -> Result<CompleteAuthOutcome, WalletError> {
         let temp_key = {
             let mut pk = self.presentation_key.lock().await;
             pk.take().ok_or_else(|| {
@@ -231,36 +250,29 @@ impl WalletAuthenticationManager {
             *pk = Some(presentation_key_hex.clone());
         }
 
-        // Look up UMP token to determine new vs existing user
-        // For now, this always returns None (new user); full overlay integration later
         let presentation_key_bytes = hex_to_bytes(&presentation_key_hex)?;
-        let _is_new_user = {
-            let guard = self.inner.read().await;
-            if let Some(ref _w) = *guard {
-                // If we somehow already have a wallet, skip lookup
-                false
-            } else {
-                // No wallet yet; use presentation key bytes as root key placeholder
-                true
-            }
-        };
 
-        // Derive root key from presentation key bytes
-        // In the full CWI flow this would combine presentation key with password via UMP token
-        // For now, use presentation key bytes directly as root key material
-        let root_key = if presentation_key_bytes.len() >= 32 {
-            presentation_key_bytes.clone()
-        } else {
-            return Err(WalletError::Internal(
-                "Presentation key too short for root key derivation".to_string(),
-            ));
-        };
+        // Resolve the real rootPrimaryKey via the UMP 2-of-3 threshold
+        // scheme (build for new users, unlock via 2 factors for returning
+        // users) -- this replaces the old placeholder that used the
+        // presentation key bytes directly as the root key.
+        let resolved = resolve_root_key(
+            &presentation_key_bytes,
+            &second_factor,
+            existing_ump_token.as_ref(),
+        )?;
 
         // Build a placeholder PrivilegedKeyManager from root key
         let priv_key_manager = Arc::new(crate::wallet::privileged::NoOpPrivilegedKeyManager);
 
-        // Construct inner wallet
-        let wallet = (self.wallet_builder)(root_key, priv_key_manager).await?;
+        // Construct inner wallet using the real root key
+        let wallet = (self.wallet_builder)(resolved.root_key, priv_key_manager).await?;
+
+        // For new users, publish the freshly built UMP token on-chain now
+        // that we have a wallet capable of create_action.
+        if let Some(ref token) = resolved.token_to_publish {
+            ump_token::create_ump_token(wallet.as_ref(), token, &self.admin_originator).await?;
+        }
 
         // Store inner wallet
         {
@@ -277,7 +289,10 @@ impl WalletAuthenticationManager {
         // Signal authentication completion
         let _ = self.auth_tx.send(true);
 
-        Ok(())
+        Ok(CompleteAuthOutcome {
+            is_new_user: resolved.is_new_user,
+            generated_recovery_key: resolved.generated_recovery_key,
+        })
     }
 
     /// Serialize current state to a JSON byte vector for persistence.
@@ -442,6 +457,96 @@ impl WalletAuthenticationManager {
             .map_err(|e| WalletError::Internal(format!("Faucet sign_action failed: {e}")))?;
 
         Ok(())
+    }
+}
+
+/// Outcome of resolving the real UMP `rootPrimaryKey` from the presentation
+/// key plus a caller-supplied second factor, against an optional existing
+/// on-chain `UMPToken`.
+struct ResolvedAuth {
+    /// The wallet's real root key (never the presentation key bytes).
+    root_key: Vec<u8>,
+    /// Whether this resolution created a brand-new `UMPToken`.
+    is_new_user: bool,
+    /// The freshly generated recovery key, only for new users.
+    generated_recovery_key: Option<Vec<u8>>,
+    /// The freshly built `UMPToken` to publish on-chain, only for new users.
+    token_to_publish: Option<UMPToken>,
+}
+
+/// Core UMP 2-of-3 decision logic for `complete_auth`, factored out as a
+/// synchronous pure function (no WAB/network/wallet dependency) so it can
+/// be unit tested directly.
+///
+/// - `existing_ump_token = None` + `SecondFactor::NewUserPassword` builds a
+///   fresh `UMPToken` (presentation + chosen password + a freshly generated
+///   recovery key) and returns the generated recovery key for the caller to
+///   persist/display exactly once.
+/// - `existing_ump_token = Some(token)` + `SecondFactor::Password` or
+///   `SecondFactor::Recovery` decrypts the existing token's `rootPrimaryKey`
+///   via the matching 2-of-3 combination.
+/// - Any other pairing (e.g. a token already exists but the caller passed
+///   `NewUserPassword`, or no token exists but the caller passed `Recovery`)
+///   is a caller error.
+fn resolve_root_key(
+    presentation_key: &[u8],
+    second_factor: &SecondFactor,
+    existing_ump_token: Option<&UMPToken>,
+) -> Result<ResolvedAuth, WalletError> {
+    match (existing_ump_token, second_factor) {
+        (None, SecondFactor::NewUserPassword(password)) => {
+            let recovery_key = bsv::primitives::random::random_bytes(32);
+            let (token, root_key) =
+                ump_token::build_ump_token(password.as_bytes(), presentation_key, &recovery_key)?;
+            Ok(ResolvedAuth {
+                root_key,
+                is_new_user: true,
+                generated_recovery_key: Some(recovery_key),
+                token_to_publish: Some(token),
+            })
+        }
+        (None, SecondFactor::Password(_)) | (None, SecondFactor::Recovery(_)) => {
+            Err(WalletError::Internal(
+                "No UMP token found for this presentation key; first-time signup requires \
+                 SecondFactor::NewUserPassword"
+                    .to_string(),
+            ))
+        }
+        (Some(_), SecondFactor::NewUserPassword(_)) => Err(WalletError::Internal(
+            "A UMP token already exists for this presentation key; use SecondFactor::Password \
+             or SecondFactor::Recovery to log in"
+                .to_string(),
+        )),
+        (Some(token), SecondFactor::Password(password)) => {
+            let root_key = ump_token::unlock_root_primary_key(
+                token,
+                &AuthFactors::PresentationPassword {
+                    presentation_key: presentation_key.to_vec(),
+                    password: password.as_bytes().to_vec(),
+                },
+            )?;
+            Ok(ResolvedAuth {
+                root_key,
+                is_new_user: false,
+                generated_recovery_key: None,
+                token_to_publish: None,
+            })
+        }
+        (Some(token), SecondFactor::Recovery(recovery_key)) => {
+            let root_key = ump_token::unlock_root_primary_key(
+                token,
+                &AuthFactors::PresentationRecovery {
+                    presentation_key: presentation_key.to_vec(),
+                    recovery_key: recovery_key.clone(),
+                },
+            )?;
+            Ok(ResolvedAuth {
+                root_key,
+                is_new_user: false,
+                generated_recovery_key: None,
+                token_to_publish: None,
+            })
+        }
     }
 }
 
@@ -1044,6 +1149,154 @@ mod tests {
         assert!(
             auth.authenticated,
             "Should be authenticated after setting inner"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // resolve_root_key: the exact UMP 2-of-3 decision logic complete_auth
+    // wires up, tested directly (no WAB/network/wallet needed).
+    // ------------------------------------------------------------------
+
+    const TEST_PASSWORD: &str = "correct horse battery staple";
+
+    fn random_presentation_key() -> Vec<u8> {
+        bsv::primitives::random::random_bytes(32)
+    }
+
+    #[test]
+    fn test_new_user_builds_ump_token_and_returns_recovery_key() {
+        let presentation_key = random_presentation_key();
+
+        let resolved = resolve_root_key(
+            &presentation_key,
+            &SecondFactor::NewUserPassword(TEST_PASSWORD.to_string()),
+            None,
+        )
+        .expect("new user resolution should succeed");
+
+        assert!(resolved.is_new_user);
+        assert!(resolved.token_to_publish.is_some());
+        let recovery_key = resolved
+            .generated_recovery_key
+            .expect("new user must get a generated recovery key");
+        assert_eq!(recovery_key.len(), 32);
+        assert_eq!(resolved.root_key.len(), 32);
+        // Root key must not be the presentation key bytes (the old bug).
+        assert_ne!(
+            resolved.root_key, presentation_key,
+            "root key must never equal the raw presentation key bytes"
+        );
+    }
+
+    #[test]
+    fn test_returning_user_password_and_recovery_and_password_recovery_agree() {
+        let presentation_key = random_presentation_key();
+
+        // Step 1: sign up, capturing the built token + generated recovery key.
+        let signup = resolve_root_key(
+            &presentation_key,
+            &SecondFactor::NewUserPassword(TEST_PASSWORD.to_string()),
+            None,
+        )
+        .unwrap();
+        let token = signup.token_to_publish.clone().unwrap();
+        let recovery_key = signup.generated_recovery_key.clone().unwrap();
+        let root_key = signup.root_key.clone();
+
+        // Mode 1: presentation + password.
+        let via_password = resolve_root_key(
+            &presentation_key,
+            &SecondFactor::Password(TEST_PASSWORD.to_string()),
+            Some(&token),
+        )
+        .expect("presentation+password should unlock");
+        assert!(!via_password.is_new_user);
+        assert_eq!(via_password.root_key, root_key);
+
+        // Mode 2: presentation + recovery.
+        let via_recovery = resolve_root_key(
+            &presentation_key,
+            &SecondFactor::Recovery(recovery_key.clone()),
+            Some(&token),
+        )
+        .expect("presentation+recovery should unlock");
+        assert!(!via_recovery.is_new_user);
+        assert_eq!(via_recovery.root_key, root_key);
+
+        // Mode 3: password + recovery (the third 2-of-3 combination),
+        // exercised directly against the UMP token / cwi_logic layer since
+        // `complete_auth`'s SecondFactor is always paired with a WAB-issued
+        // presentation key.
+        let via_password_recovery = ump_token::unlock_root_primary_key(
+            &token,
+            &AuthFactors::PasswordRecovery {
+                password: TEST_PASSWORD.as_bytes().to_vec(),
+                recovery_key: recovery_key.clone(),
+            },
+        )
+        .expect("password+recovery should unlock");
+        assert_eq!(via_password_recovery, root_key);
+    }
+
+    #[test]
+    fn test_returning_user_wrong_password_fails() {
+        let presentation_key = random_presentation_key();
+        let signup = resolve_root_key(
+            &presentation_key,
+            &SecondFactor::NewUserPassword(TEST_PASSWORD.to_string()),
+            None,
+        )
+        .unwrap();
+        let token = signup.token_to_publish.unwrap();
+
+        let result = resolve_root_key(
+            &presentation_key,
+            &SecondFactor::Password("wrong-password".to_string()),
+            Some(&token),
+        );
+
+        assert!(
+            result.is_err(),
+            "wrong password must not unlock the root key"
+        );
+    }
+
+    #[test]
+    fn test_new_user_second_factor_recovery_without_token_is_rejected() {
+        let presentation_key = random_presentation_key();
+
+        let result = resolve_root_key(
+            &presentation_key,
+            &SecondFactor::Recovery(vec![0u8; 32]),
+            None,
+        );
+
+        assert!(
+            result.is_err(),
+            "a single factor (recovery only, no token) must never resolve a root key"
+        );
+    }
+
+    #[test]
+    fn test_signup_again_with_existing_token_is_rejected() {
+        let presentation_key = random_presentation_key();
+        let signup = resolve_root_key(
+            &presentation_key,
+            &SecondFactor::NewUserPassword(TEST_PASSWORD.to_string()),
+            None,
+        )
+        .unwrap();
+        let token = signup.token_to_publish.unwrap();
+
+        let result = resolve_root_key(
+            &presentation_key,
+            &SecondFactor::NewUserPassword("another-password".to_string()),
+            Some(&token),
+        );
+
+        assert!(
+            result.is_err(),
+            "signing up again over an existing token must be rejected"
         );
     }
 }

--- a/src/auth_manager/types.rs
+++ b/src/auth_manager/types.rs
@@ -58,6 +58,46 @@ pub struct Profile {
     pub linked_methods: Vec<LinkedMethod>,
 }
 
+/// The second UMP auth factor supplied by the caller to `complete_auth`,
+/// alongside the presentation key that `complete_auth` always obtains from
+/// the WAB server.
+///
+/// The WAB only ever hands out the presentation-key factor; it never sees
+/// the password or the recovery key, so it can never reconstruct a wallet
+/// key on its own. Which variant is valid depends on whether a `UMPToken`
+/// already exists on-chain for this presentation key (returning user) or
+/// not (new user):
+///
+/// - No existing token + `NewUserPassword` -> registers: builds a fresh
+///   `UMPToken` (all 3 factors known simultaneously at signup) and returns
+///   the freshly generated recovery key so the caller can show it to the
+///   user exactly once.
+/// - Existing token + `Password` -> unlocks via presentation+password.
+/// - Existing token + `Recovery` -> unlocks via presentation+recovery.
+#[derive(Debug, Clone)]
+pub enum SecondFactor {
+    /// New-user registration: caller-chosen password. A recovery key is
+    /// generated internally and returned via
+    /// `CompleteAuthOutcome::generated_recovery_key`.
+    NewUserPassword(String),
+    /// Returning-user login via presentation + password.
+    Password(String),
+    /// Returning-user login via presentation + recovery key (raw bytes).
+    Recovery(Vec<u8>),
+}
+
+/// Result of a successful `complete_auth` call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompleteAuthOutcome {
+    /// True if this call created a brand-new `UMPToken` (first-time signup).
+    pub is_new_user: bool,
+    /// Only `Some` for new users: the freshly generated 32-byte recovery
+    /// key. This is the *only* time it is ever exposed — the caller must
+    /// display/persist it immediately, since it is never derivable again
+    /// except by decrypting the on-chain `UMPToken` with 2 other factors.
+    pub generated_recovery_key: Option<Vec<u8>>,
+}
+
 /// Type alias for the async closure that constructs a wallet from key material.
 ///
 /// Called after authentication succeeds with the derived root key bytes and

--- a/src/auth_manager/ump_token.rs
+++ b/src/auth_manager/ump_token.rs
@@ -7,6 +7,10 @@
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
+use bsv::primitives::hash::sha256;
+use bsv::primitives::private_key::PrivateKey;
+use bsv::primitives::random::random_bytes;
+use bsv::primitives::symmetric_key::SymmetricKey;
 use bsv::script::locking_script::LockingScript;
 use bsv::script::templates::push_drop::{decode as decode_push_drop, LockPosition, PushDrop};
 use bsv::wallet::interfaces::{
@@ -15,7 +19,12 @@ use bsv::wallet::interfaces::{
 };
 use bsv::wallet::types::{Counterparty, CounterpartyType, Protocol};
 
+use super::cwi_logic::{derive_password_key, xor_keys};
 use crate::WalletError;
+
+/// Expected byte length of each UMP auth factor (presentation key, recovery
+/// key, and the derived password key) and of the root primary/privileged keys.
+pub const UMP_FACTOR_SIZE: usize = 32;
 
 /// Admin basket name for UMP tokens (matching TS constant).
 pub const UMP_BASKET: &str = "admin user management token";
@@ -350,9 +359,422 @@ pub fn decode_ump_token_fields(fields: &[Vec<u8>]) -> Result<UMPToken, WalletErr
     })
 }
 
+// ============================================================================
+// 2-of-3 UMP threshold scheme (XOR + AES-GCM symmetric encryption, NOT Shamir)
+// ============================================================================
+//
+// The wallet's `rootPrimaryKey` is stored three times in the token, each
+// encrypted under the XOR of a *pair* of the three auth factors
+// (presentation key, password key, recovery key):
+//
+//   password_presentation_primary = SymEnc(rootPrimaryKey, XOR(presentation, password))
+//   password_recovery_primary     = SymEnc(rootPrimaryKey, XOR(password,     recovery))
+//   presentation_recovery_primary = SymEnc(rootPrimaryKey, XOR(presentation, recovery))
+//
+// Any 2 of the 3 factors reconstruct the XOR key and decrypt the root key.
+// A parallel `rootPrivilegedKey` is protected by the two combinations that
+// don't require re-deriving the root key first: `password + rootPrimaryKey`
+// and `presentation + recovery`. The three raw factors are also each backed
+// up encrypted directly under the privileged key so they can be recovered
+// once the privileged key is known (e.g. for a password change).
+
+/// The two factors an existing user supplies to unlock a `UMPToken`'s
+/// `rootPrimaryKey`. Any of the three 2-of-3 combinations works and all
+/// yield the identical root key.
+pub enum AuthFactors {
+    /// Presentation key (from the WAB, after an Auth Method passes) + password.
+    PresentationPassword {
+        /// 256-bit presentation key bytes.
+        presentation_key: Vec<u8>,
+        /// Raw password bytes (PBKDF2'd internally against the token's salt).
+        password: Vec<u8>,
+    },
+    /// Password + user-held recovery key (no WAB interaction needed).
+    PasswordRecovery {
+        /// Raw password bytes (PBKDF2'd internally against the token's salt).
+        password: Vec<u8>,
+        /// 256-bit recovery key bytes.
+        recovery_key: Vec<u8>,
+    },
+    /// Presentation key + recovery key (password forgotten / not needed).
+    PresentationRecovery {
+        /// 256-bit presentation key bytes.
+        presentation_key: Vec<u8>,
+        /// 256-bit recovery key bytes.
+        recovery_key: Vec<u8>,
+    },
+}
+
+/// Validate that a factor byte slice is exactly [`UMP_FACTOR_SIZE`] bytes.
+fn require_factor_size(name: &str, bytes: &[u8]) -> Result<(), WalletError> {
+    if bytes.len() != UMP_FACTOR_SIZE {
+        return Err(WalletError::Internal(format!(
+            "{} must be {} bytes, got {}",
+            name,
+            UMP_FACTOR_SIZE,
+            bytes.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Build a brand-new `UMPToken` for a first-time user, given all three
+/// factors: the presentation key just released by the WAB, a password the
+/// user just chose, and a recovery key just generated for them.
+///
+/// Generates a fresh random `rootPrimaryKey` (the wallet's actual root key)
+/// and a fresh random `rootPrivilegedKey`, then populates every encrypted
+/// UMP token field so that:
+/// - any 2 of {presentation, password, recovery} unlock the root primary key
+/// - {password, rootPrimaryKey} or {presentation, recovery} unlock the root
+///   privileged key
+/// - all three raw factors are recoverable once the privileged key is known
+///
+/// # Returns
+/// `(token, root_primary_key)` — the caller is responsible for publishing
+/// the token on-chain (via [`create_ump_token`]) and for using
+/// `root_primary_key` to construct the user's wallet.
+///
+/// # Arguments
+/// * `password` - Raw password bytes chosen by the user
+/// * `presentation_key` - 32-byte presentation key released by the WAB
+/// * `recovery_key` - 32-byte recovery key (generate randomly for new users)
+pub fn build_ump_token(
+    password: &[u8],
+    presentation_key: &[u8],
+    recovery_key: &[u8],
+) -> Result<(UMPToken, Vec<u8>), WalletError> {
+    require_factor_size("presentation_key", presentation_key)?;
+    require_factor_size("recovery_key", recovery_key)?;
+
+    let root_primary_key = random_bytes(UMP_FACTOR_SIZE);
+    let root_privileged_key = random_bytes(UMP_FACTOR_SIZE);
+    let password_salt = random_bytes(UMP_FACTOR_SIZE);
+    let password_key = derive_password_key(password, &password_salt);
+    require_factor_size("derived password_key", &password_key)?;
+
+    let xor_pw_pres = xor_keys(presentation_key, &password_key);
+    let xor_pw_rec = xor_keys(&password_key, recovery_key);
+    let xor_pres_rec = xor_keys(presentation_key, recovery_key);
+
+    let password_presentation_primary = sym_encrypt(&xor_pw_pres, &root_primary_key)?;
+    let password_recovery_primary = sym_encrypt(&xor_pw_rec, &root_primary_key)?;
+    let presentation_recovery_primary = sym_encrypt(&xor_pres_rec, &root_primary_key)?;
+
+    let xor_pw_primary = xor_keys(&password_key, &root_primary_key);
+    let password_primary_privileged = sym_encrypt(&xor_pw_primary, &root_privileged_key)?;
+    let presentation_recovery_privileged = sym_encrypt(&xor_pres_rec, &root_privileged_key)?;
+
+    let presentation_key_encrypted = sym_encrypt(&root_privileged_key, presentation_key)?;
+    let password_key_encrypted = sym_encrypt(&root_privileged_key, &password_key)?;
+    let recovery_key_encrypted = sym_encrypt(&root_privileged_key, recovery_key)?;
+
+    let token = UMPToken {
+        password_salt,
+        password_presentation_primary,
+        password_recovery_primary,
+        presentation_recovery_primary,
+        password_primary_privileged,
+        presentation_recovery_privileged,
+        presentation_hash: sha256(presentation_key).to_vec(),
+        recovery_hash: sha256(recovery_key).to_vec(),
+        presentation_key_encrypted,
+        password_key_encrypted,
+        recovery_key_encrypted,
+        profiles_encrypted: None,
+        current_outpoint: None,
+    };
+
+    Ok((token, root_primary_key))
+}
+
+/// Unlock (decrypt) an existing `UMPToken`'s `rootPrimaryKey` using any 2 of
+/// the 3 auth factors.
+///
+/// Derives the password key from the token's stored salt when a password is
+/// supplied, XORs the appropriate factor pair, and uses the result as an
+/// AES-256 key to decrypt the matching primary-key slot. A wrong password
+/// (or wrong recovery/presentation key) produces a different XOR key, which
+/// fails AEAD decryption and returns an `Err`.
+///
+/// # Arguments
+/// * `token` - The on-chain `UMPToken` to unlock
+/// * `factors` - The 2 factors supplied by the caller
+pub fn unlock_root_primary_key(
+    token: &UMPToken,
+    factors: &AuthFactors,
+) -> Result<Vec<u8>, WalletError> {
+    let (xor_key, ciphertext) = match factors {
+        AuthFactors::PresentationPassword {
+            presentation_key,
+            password,
+        } => {
+            require_factor_size("presentation_key", presentation_key)?;
+            let password_key = derive_password_key(password, &token.password_salt);
+            (
+                xor_keys(presentation_key, &password_key),
+                &token.password_presentation_primary,
+            )
+        }
+        AuthFactors::PasswordRecovery {
+            password,
+            recovery_key,
+        } => {
+            require_factor_size("recovery_key", recovery_key)?;
+            let password_key = derive_password_key(password, &token.password_salt);
+            (
+                xor_keys(&password_key, recovery_key),
+                &token.password_recovery_primary,
+            )
+        }
+        AuthFactors::PresentationRecovery {
+            presentation_key,
+            recovery_key,
+        } => {
+            require_factor_size("presentation_key", presentation_key)?;
+            require_factor_size("recovery_key", recovery_key)?;
+            (
+                xor_keys(presentation_key, recovery_key),
+                &token.presentation_recovery_primary,
+            )
+        }
+    };
+
+    sym_decrypt(&xor_key, ciphertext)
+}
+
+/// Encrypt `plaintext` with `key_bytes` as an AES-256 `SymmetricKey`.
+fn sym_encrypt(key_bytes: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, WalletError> {
+    let key = SymmetricKey::from_bytes(key_bytes)
+        .map_err(|e| WalletError::Internal(format!("Invalid UMP symmetric key: {e}")))?;
+    key.encrypt(plaintext)
+        .map_err(|e| WalletError::Internal(format!("UMP symmetric encryption failed: {e}")))
+}
+
+/// Decrypt `ciphertext` with `key_bytes` as an AES-256 `SymmetricKey`.
+fn sym_decrypt(key_bytes: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, WalletError> {
+    let key = SymmetricKey::from_bytes(key_bytes)
+        .map_err(|e| WalletError::Internal(format!("Invalid UMP symmetric key: {e}")))?;
+    key.decrypt(ciphertext)
+        .map_err(|e| WalletError::Internal(format!("UMP symmetric decryption failed: {e}")))
+}
+
+/// Compute the SHA-256 hash of a presentation key, for UMP token lookup by tag.
+pub fn presentation_hash_hex(presentation_key: &[u8]) -> String {
+    sha256(presentation_key)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ------------------------------------------------------------------
+    // 2-of-3 UMP threshold scheme: build_ump_token / unlock_root_primary_key
+    // ------------------------------------------------------------------
+
+    const PASSWORD: &[u8] = b"correct horse battery staple";
+
+    fn make_test_token() -> (UMPToken, Vec<u8>, Vec<u8>, Vec<u8>) {
+        let presentation_key = random_bytes(UMP_FACTOR_SIZE);
+        let recovery_key = random_bytes(UMP_FACTOR_SIZE);
+        let (token, root_primary_key) = build_ump_token(PASSWORD, &presentation_key, &recovery_key)
+            .expect("build_ump_token should succeed");
+        (token, root_primary_key, presentation_key, recovery_key)
+    }
+
+    #[test]
+    fn test_unlock_mode1_presentation_password() {
+        let (token, root_key, presentation_key, _recovery_key) = make_test_token();
+
+        let unlocked = unlock_root_primary_key(
+            &token,
+            &AuthFactors::PresentationPassword {
+                presentation_key,
+                password: PASSWORD.to_vec(),
+            },
+        )
+        .expect("presentation+password should unlock the root key");
+
+        assert_eq!(unlocked, root_key);
+    }
+
+    #[test]
+    fn test_unlock_mode2_presentation_recovery() {
+        let (token, root_key, presentation_key, recovery_key) = make_test_token();
+
+        let unlocked = unlock_root_primary_key(
+            &token,
+            &AuthFactors::PresentationRecovery {
+                presentation_key,
+                recovery_key,
+            },
+        )
+        .expect("presentation+recovery should unlock the root key");
+
+        assert_eq!(unlocked, root_key);
+    }
+
+    #[test]
+    fn test_unlock_mode3_recovery_password() {
+        let (token, root_key, _presentation_key, recovery_key) = make_test_token();
+
+        let unlocked = unlock_root_primary_key(
+            &token,
+            &AuthFactors::PasswordRecovery {
+                password: PASSWORD.to_vec(),
+                recovery_key,
+            },
+        )
+        .expect("password+recovery should unlock the root key");
+
+        assert_eq!(unlocked, root_key);
+    }
+
+    #[test]
+    fn test_all_three_modes_yield_the_same_root_key() {
+        let (token, root_key, presentation_key, recovery_key) = make_test_token();
+
+        let via_pw = unlock_root_primary_key(
+            &token,
+            &AuthFactors::PresentationPassword {
+                presentation_key: presentation_key.clone(),
+                password: PASSWORD.to_vec(),
+            },
+        )
+        .unwrap();
+        let via_recovery = unlock_root_primary_key(
+            &token,
+            &AuthFactors::PresentationRecovery {
+                presentation_key: presentation_key.clone(),
+                recovery_key: recovery_key.clone(),
+            },
+        )
+        .unwrap();
+        let via_pw_recovery = unlock_root_primary_key(
+            &token,
+            &AuthFactors::PasswordRecovery {
+                password: PASSWORD.to_vec(),
+                recovery_key: recovery_key.clone(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(via_pw, root_key);
+        assert_eq!(via_recovery, root_key);
+        assert_eq!(via_pw_recovery, root_key);
+        assert_eq!(via_pw, via_recovery);
+        assert_eq!(via_recovery, via_pw_recovery);
+    }
+
+    #[test]
+    fn test_wrong_password_fails() {
+        let (token, _root_key, presentation_key, _recovery_key) = make_test_token();
+
+        let result = unlock_root_primary_key(
+            &token,
+            &AuthFactors::PresentationPassword {
+                presentation_key,
+                password: b"totally-wrong-password".to_vec(),
+            },
+        );
+
+        assert!(
+            result.is_err(),
+            "wrong password must not unlock the root key"
+        );
+    }
+
+    #[test]
+    fn test_wrong_recovery_key_fails() {
+        let (token, _root_key, presentation_key, _recovery_key) = make_test_token();
+        let wrong_recovery = random_bytes(UMP_FACTOR_SIZE);
+
+        let result = unlock_root_primary_key(
+            &token,
+            &AuthFactors::PresentationRecovery {
+                presentation_key,
+                recovery_key: wrong_recovery,
+            },
+        );
+
+        assert!(
+            result.is_err(),
+            "wrong recovery key must not unlock the root key"
+        );
+    }
+
+    #[test]
+    fn test_wrong_presentation_key_fails() {
+        let (token, _root_key, _presentation_key, recovery_key) = make_test_token();
+        let wrong_presentation = random_bytes(UMP_FACTOR_SIZE);
+
+        let result = unlock_root_primary_key(
+            &token,
+            &AuthFactors::PresentationRecovery {
+                presentation_key: wrong_presentation,
+                recovery_key,
+            },
+        );
+
+        assert!(
+            result.is_err(),
+            "wrong presentation key must not unlock the root key"
+        );
+    }
+
+    #[test]
+    fn test_build_ump_token_rejects_bad_factor_sizes() {
+        let short_presentation = vec![0u8; 16];
+        let recovery_key = random_bytes(UMP_FACTOR_SIZE);
+        let result = build_ump_token(PASSWORD, &short_presentation, &recovery_key);
+        assert!(result.is_err(), "short presentation key must be rejected");
+
+        let presentation_key = random_bytes(UMP_FACTOR_SIZE);
+        let short_recovery = vec![0u8; 8];
+        let result = build_ump_token(PASSWORD, &presentation_key, &short_recovery);
+        assert!(result.is_err(), "short recovery key must be rejected");
+    }
+
+    #[test]
+    fn test_build_ump_token_populates_hashes_and_salt() {
+        let (token, _root_key, presentation_key, recovery_key) = make_test_token();
+
+        assert_eq!(token.presentation_hash, sha256(&presentation_key).to_vec());
+        assert_eq!(token.recovery_hash, sha256(&recovery_key).to_vec());
+        assert_eq!(token.password_salt.len(), UMP_FACTOR_SIZE);
+        assert_eq!(presentation_hash_hex(&presentation_key).len(), 64);
+    }
+
+    #[test]
+    fn test_root_privileged_key_unlockable_via_password_and_primary() {
+        // password_primary_privileged = SymEnc(rootPrivilegedKey, XOR(passwordKey, rootPrimaryKey))
+        let (token, root_primary_key, _presentation_key, _recovery_key) = make_test_token();
+        let password_key = derive_password_key(PASSWORD, &token.password_salt);
+        let xor = xor_keys(&password_key, &root_primary_key);
+        let root_privileged_key =
+            sym_decrypt(&xor, &token.password_primary_privileged).expect("should decrypt");
+        assert_eq!(root_privileged_key.len(), UMP_FACTOR_SIZE);
+    }
+
+    #[test]
+    fn test_root_privileged_key_unlockable_via_presentation_and_recovery() {
+        // presentation_recovery_privileged = SymEnc(rootPrivilegedKey, XOR(presentation, recovery))
+        let (token, root_primary_key, presentation_key, recovery_key) = make_test_token();
+        let xor = xor_keys(&presentation_key, &recovery_key);
+        let root_privileged_key =
+            sym_decrypt(&xor, &token.presentation_recovery_privileged).expect("should decrypt");
+
+        // Cross-check: the same privileged key must also decrypt via the
+        // password+primary path.
+        let password_key = derive_password_key(PASSWORD, &token.password_salt);
+        let xor2 = xor_keys(&password_key, &root_primary_key);
+        let root_privileged_key2 =
+            sym_decrypt(&xor2, &token.password_primary_privileged).expect("should decrypt");
+        assert_eq!(root_privileged_key, root_privileged_key2);
+    }
 
     #[test]
     fn test_ump_token_serialization() {


### PR DESCRIPTION
## What

Wires the real **UMP 2-of-3 threshold authentication** into `auth_manager::complete_auth`, replacing a placeholder that used the presentation key alone as the root key.

Before this change, `complete_auth` did:

```rust
let root_key = presentation_key_bytes.clone(); // For now… placeholder
```

which means the WAB's presentation key **alone** could reconstruct the wallet's root key — defeating the purpose of the UMP multi-factor scheme. This ports the TS `CWIStyleWalletManager` behavior: the root primary key is resolved from **two of three** independent factors (password / presentation / recovery) via XOR-combined UMP token slots.

## Changes

- `ump_token.rs` — `AuthFactors`, `build_ump_token`, `unlock_root_primary_key`, `presentation_hash_hex` (UMP token construction + 2-of-3 unlock)
- `cwi_logic.rs` — `derive_password_key` + `UMP_PASSWORD_KEY_SIZE` (32-byte PBKDF2 password-key factor)
- `types.rs` — `SecondFactor`, `CompleteAuthOutcome`
- `mod.rs` — `resolve_root_key` wiring into `complete_auth`

+813 / −33 across 4 files.

## TS parity

Verified against `@bsv/wallet-toolbox-client`'s `CWIStyleWalletManager`:
- `PBKDF2_NUM_ROUNDS = 7777`, `sha512`, 32-byte derivation — **exact match** (the legacy/default UMP KDF path).
- Root key resolves identically from any two of the three factors.

## Testing

- `cargo build -p bsv-wallet-toolbox` — green
- `cargo test -p bsv-wallet-toolbox --lib` — **412 passed, 0 failed**, including the new UMP suite:
  - `test_all_three_modes_yield_the_same_root_key`
  - `test_unlock_mode{1,2,3}_*` (password+presentation, presentation+recovery, recovery+password)
  - `test_wrong_{password,presentation_key,recovery_key}_fails`
  - `test_derive_password_key_*` (deterministic, salt-sensitive, 32-byte)

Integration (`tests/`) suite not run in CI-local (some require network) — the change is lib-only auth code fully covered by the lib unit tests above.

## Notes

Forward-ported onto current `main` (the original branch's `ump_token.rs` had diverged); the `UMPToken` structs were byte-identical, so the port was mechanical — one import-block conflict, resolved. The newer argon2id KDF path in TS is **out of scope**; this matches the deployed WAB's legacy pbkdf2(7777) path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
