### PR TITLE
feat(monitor): add fallible post-task callback

### DIFF
--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -52,6 +52,10 @@ pub const ONE_WEEK: u64 = 7 * ONE_DAY;
 pub type AsyncCallback<T> =
     Arc<dyn Fn(T) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
 
+/// A fallible async callback used to place a durability boundary after a task.
+pub type AsyncResultCallback<T> =
+    Arc<dyn Fn(T) -> Pin<Box<dyn Future<Output = WalletResult<()>> + Send>> + Send + Sync>;
+
 // ---------------------------------------------------------------------------
 // MonitorOptions
 // ---------------------------------------------------------------------------
@@ -89,6 +93,11 @@ pub struct MonitorOptions {
 
     /// Hook called when a transaction status changes.
     pub on_tx_status_changed: Option<AsyncCallback<(String, String)>>,
+
+    /// Fallible hook run after a monitor task finishes and before the scheduler
+    /// starts another task. Failures pause scheduling and retry
+    /// with backoff until the hook succeeds or the monitor is stopped.
+    pub after_task: Option<AsyncResultCallback<String>>,
 }
 
 impl Default for MonitorOptions {
@@ -104,6 +113,7 @@ impl Default for MonitorOptions {
             on_tx_broadcasted: None,
             on_tx_proven: None,
             on_tx_status_changed: None,
+            after_task: None,
         }
     }
 }
@@ -204,6 +214,31 @@ async fn run_task_isolated(
     }
 }
 
+/// Wait for an embedding's durable-write barrier after every task outcome.
+/// A task may commit part of its work before returning an error, and monitor
+/// event logging itself writes storage, so the barrier intentionally runs only
+/// after both have completed.
+async fn await_after_task(
+    callback: &AsyncResultCallback<String>,
+    task_name: &str,
+    running: &Arc<AtomicBool>,
+) -> bool {
+    let mut retry_delay_secs = 1_u64;
+    while running.load(Ordering::SeqCst) {
+        match callback(task_name.to_owned()).await {
+            Ok(()) => return true,
+            Err(e) => {
+                error!(
+                    "monitor after_task callback failed after {task_name}: {e}; retrying in {retry_delay_secs}s"
+                );
+                tokio::time::sleep(tokio::time::Duration::from_secs(retry_delay_secs)).await;
+                retry_delay_secs = retry_delay_secs.saturating_mul(2).min(5);
+            }
+        }
+    }
+    false
+}
+
 /// Truncate `log` to at most `max` BYTES on a char boundary. `&log[..1024]` was
 /// a latent panic (F3): provider error strings are interpolated into task logs,
 /// and a multi-byte char straddling the cut would unwind the monitor loop.
@@ -257,6 +292,7 @@ impl Monitor {
         let _check_now = self.check_now.clone();
         let _deactivated_headers = self.deactivated_headers.clone();
         let task_run_wait_msecs = self.options.task_run_wait_msecs;
+        let after_task = self.options.after_task.clone();
 
         // Take tasks out of self for the spawned future.
         // They will be returned when stop_tasks is called.
@@ -324,6 +360,11 @@ impl Monitor {
                                 format!("monitor task {} runTask error: {}", task.name(), e);
                             error!("{}", details);
                             let _ = log_event(&storage, "error1", &details).await;
+                        }
+                    }
+                    if let Some(ref callback) = after_task {
+                        if !await_after_task(callback, task.name(), &running).await {
+                            break;
                         }
                     }
                 }
@@ -652,6 +693,17 @@ impl MonitorBuilder {
         self
     }
 
+    /// Set a fallible hook that runs after each completed task.
+    ///
+    /// The hook runs before the scheduler starts another task. An error pauses
+    /// scheduling and retries with backoff, so embeddings fail closed without
+    /// permanently turning off background processing when a durable replica or
+    /// external acknowledgement is temporarily unavailable.
+    pub fn after_task(mut self, callback: AsyncResultCallback<String>) -> Self {
+        self.options.after_task = Some(callback);
+        self
+    }
+
     /// Build the Monitor instance.
     ///
     /// Validates that required fields (chain, storage, services) are set.
@@ -813,6 +865,7 @@ impl MonitorBuilder {
 mod tests {
     use super::*;
     use crate::services::types::BlockHeader;
+    use std::sync::atomic::AtomicUsize;
 
     // A minimal mock WalletServices for testing.
     // Only constructed indirectly via trait-object boxing in tests below
@@ -1040,6 +1093,27 @@ mod tests {
         let out = run_task_isolated(&mut task).await;
         let err = out.expect_err("a panic must surface as an Err, not an unwind");
         assert!(err.to_string().contains("PANICKED"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn after_task_retries_a_transient_durability_failure_without_stopping() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_callback = Arc::clone(&attempts);
+        let callback: AsyncResultCallback<String> = Arc::new(move |_| {
+            let attempts = Arc::clone(&attempts_for_callback);
+            Box::pin(async move {
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(WalletError::Internal("temporary artifact outage".to_string()))
+                } else {
+                    Ok(())
+                }
+            })
+        });
+        let running = Arc::new(AtomicBool::new(true));
+
+        assert!(await_after_task(&callback, "test-task", &running).await);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert!(running.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/src/wallet/setup.rs
+++ b/src/wallet/setup.rs
@@ -15,7 +15,7 @@ use bsv::wallet::types::{Counterparty, CounterpartyType, Protocol};
 use bsv::wallet::KeyDeriverApi;
 
 use crate::error::{WalletError, WalletResult};
-use crate::monitor::Monitor;
+use crate::monitor::{AsyncResultCallback, Monitor};
 use crate::services::traits::WalletServices;
 use crate::signer::signing_provider::SigningProvider;
 use crate::storage::manager::WalletStorageManager;
@@ -231,6 +231,7 @@ pub struct WalletBuilder {
     services: Option<Arc<dyn WalletServices>>,
     use_default_services: bool,
     monitor_enabled: bool,
+    monitor_after_task: Option<AsyncResultCallback<String>>,
     privileged_key_manager: Option<Arc<dyn PrivilegedKeyManager>>,
     pool_max_connections: Option<u32>,
     pool_min_connections: Option<u32>,
@@ -259,6 +260,7 @@ impl WalletBuilder {
             // — "works out of the box" means the monitor runs unless the caller
             // explicitly opts out with `without_monitor()`.
             monitor_enabled: true,
+            monitor_after_task: None,
             privileged_key_manager: None,
             pool_max_connections: None,
             pool_min_connections: None,
@@ -396,6 +398,16 @@ impl WalletBuilder {
     /// is a no-op kept for back-compatibility with 0.3.3-era callers.
     pub fn with_monitor(mut self) -> Self {
         self.monitor_enabled = true;
+        self
+    }
+
+    /// Run a fallible hook after each completed background monitor task.
+    ///
+    /// An error pauses the monitor and retries before it starts another task.
+    /// This is useful when an embedding needs a durable replica or external
+    /// acknowledgement to keep pace with background storage changes.
+    pub fn with_monitor_after_task(mut self, callback: AsyncResultCallback<String>) -> Self {
+        self.monitor_after_task = Some(callback);
         self
     }
 
@@ -602,12 +614,15 @@ impl WalletBuilder {
         // rust-mpc#147 faucet never broadcast a single tx that way).
         let monitor = if self.monitor_enabled {
             if let Some(ref svc) = services {
-                let mut monitor = crate::monitor::Monitor::builder()
+                let mut builder = crate::monitor::Monitor::builder()
                     .chain(chain.clone())
                     .storage(storage.clone())
                     .services(svc.clone())
-                    .default_tasks()
-                    .build()?;
+                    .default_tasks();
+                if let Some(callback) = self.monitor_after_task {
+                    builder = builder.after_task(callback);
+                }
+                let mut monitor = builder.build()?;
                 monitor.start_tasks()?;
                 tracing::info!("wallet monitor started (default; opt out with without_monitor())");
                 Some(Arc::new(monitor))


### PR DESCRIPTION
## Summary

- add an optional fallible `after_task` monitor callback
- expose the callback through `WalletBuilder`
- retry failed callbacks with bounded exponential backoff while the monitor remains running
- cover a transient callback failure followed by successful retry

The callback runs after each task outcome and its monitor event write. This gives embeddings a generic, opt-in durable-replication boundary without adding application-specific recovery code to the toolbox.

## Validation

- `CARGO_INCREMENTAL=0 cargo test --offline`
- `CARGO_INCREMENTAL=0 cargo test --offline after_task_retries_a_transient_durability_failure_without_stopping`